### PR TITLE
Avoid storing nullifier on insufficient balance

### DIFF
--- a/contracts/privacy-pools/src/lib.rs
+++ b/contracts/privacy-pools/src/lib.rs
@@ -181,20 +181,21 @@ impl PrivacyPoolsContract {
         if res.is_err() || !res.unwrap() {
             return vec![env, String::from_str(env, ERROR_COIN_OWNERSHIP_PROOF)]
         }
-        
-        // Add nullifier to used nullifiers
-        nullifiers.push_back(nullifier);
-        env.storage().instance().set(&NULL_KEY, &nullifiers);
 
-        // Check and update contract balance
+        // Check contract balance before updating state
         let current_balance = env.storage().instance().get(&BALANCE_KEY)
             .unwrap_or(0);
         if current_balance < FIXED_AMOUNT {
             return vec![env, String::from_str(env, ERROR_INSUFFICIENT_BALANCE)]
         }
 
+        // Add nullifier to used nullifiers only after all checks pass
+        nullifiers.push_back(nullifier);
+        env.storage().instance().set(&NULL_KEY, &nullifiers);
+
+        // Update contract balance
         env.storage().instance().set(&BALANCE_KEY, &(current_balance - FIXED_AMOUNT));
-        
+
         return vec![env, String::from_str(env, ERROR_WITHDRAW_SUCCESS)]
     }
 

--- a/contracts/privacy-pools/src/test.rs
+++ b/contracts/privacy-pools/src/test.rs
@@ -237,6 +237,9 @@ fn test_withdraw_insufficient_balance() {
             String::from_str(&env, ERROR_INSUFFICIENT_BALANCE)
         ]
     );
+
+    // Ensure nullifier was not stored when withdrawal failed
+    assert_eq!(client.get_nullifiers().len(), 0);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Prevent recording a nullifier when withdrawal fails due to insufficient balance
- Add regression test ensuring nullifiers remain empty after failed withdrawal

## Testing
- `cargo test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_689cd784bdbc832083e4c4694d726eb4