### PR TITLE
fix typo in dummy circuit comment

### DIFF
--- a/circuits/dummy.circom
+++ b/circuits/dummy.circom
@@ -4,7 +4,7 @@ include "commitment.circom";
 include "comparators.circom";
 
 // This circuit is for withdrawing by demonstrating only that the withdrawer
-// knows the secret and nullifier, without prooving inclusion of the commitment in the Merkle tree.
+// knows the secret and nullifier, without proving inclusion of the commitment in the Merkle tree.
 // This is for testing purposes only, to enable testing depositing and withdrawing coins prior to 
 // testing the full Merkle tree implementation.
 


### PR DESCRIPTION
## Summary
- fix typo in dummy circuit comment

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_689ce0adc070832097bed9ef04376489