### PR TITLE
Add balance and nullifier checks after failed withdraw

### DIFF
--- a/contracts/privacy-pools/src/test.rs
+++ b/contracts/privacy-pools/src/test.rs
@@ -214,6 +214,10 @@ fn test_deposit_and_withdraw_wrong_proof() {
             String::from_str(&env, ERROR_COIN_OWNERSHIP_PROOF)
         ]
     );
+    assert_eq!(client.get_balance(), FIXED_AMOUNT);
+    let nullifiers = client.get_nullifiers();
+    assert_eq!(nullifiers.len(), 0);
+
 
     // env.cost_estimate().budget().print();
 }


### PR DESCRIPTION
## Summary
- extend wrong-proof withdrawal test to verify balance and nullifier states remain unchanged

## Testing
- `cargo test -p privacy-pools`


------
https://chatgpt.com/codex/tasks/task_e_689cddca86a483209a287c4d99f2a531